### PR TITLE
Add new table component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -66,6 +66,10 @@ export default {
         to: '/Card',
         label: 'Card',
       },
+      {
+        to: '/Table',
+        label: 'Table',
+      },
     ],
     overviewLinks: [
       {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="table-container">
+    <table>
+      <thead>
+        <tr>
+          <th
+            v-for="(header, index) in headers"
+            :key="index"
+            :style="{ textAlign: header.rightAlign ? 'right' : 'initial'  }"
+          >
+            {{ header.label }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(row, rowIndex) in items" :key="'row' + rowIndex">
+          <td
+            v-for="(col, colIndex) in Object.keys(row).length"
+            :key="'col' + colIndex"
+            :style="{ textAlign: headers[colIndex].rightAlign ? 'right' : 'initial'  }"
+          >
+            {{ row[headers[colIndex].valueKey] }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import 'highlight.js/styles/default.css';
+
+export default {
+  name: 'Table',
+  props: {
+    items: {
+      type: Array,
+      required: true,
+      default: () => [],
+    },
+    headers: {
+      type: Array,
+      required: true,
+      default: () => [],
+      validator: (headers) => {
+        const requiredKeys = ['label', 'valueKey', 'rightAlign'];
+        return headers.every(
+          (header) => requiredKeys.every(
+            (key) => Object.prototype.hasOwnProperty.call(header, key),
+          ),
+        );
+      },
+    },
+  },
+};
+</script>
+
+<style scoped>
+.table-container th {
+  font-weight: normal;
+  border-bottom: 2px dashed;
+  padding-bottom: .35em;
+}
+.table-container td {
+  padding-top: .5em;
+}
+</style>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -10,6 +10,7 @@ import Divider from './Divider.vue';
 import ImageContainer from './ImageContainer.vue';
 import CodeContent from './Code.vue';
 import Card from './Card.vue';
+import Table from './Table.vue';
 
 require('typeface-roboto-condensed');
 
@@ -25,6 +26,7 @@ const Components = {
   ImageContainer,
   CodeContent,
   Card,
+  Table,
 };
 
 Object.keys(Components).forEach((name) => {

--- a/src/docs/TableDocs.vue
+++ b/src/docs/TableDocs.vue
@@ -1,0 +1,108 @@
+<template>
+  <div>
+    <divider/>
+
+    <header-large>
+      Table
+    </header-large>
+
+    <text-large>
+      The `table` component provides the ability to organize
+      content into different rows.
+    </text-large>
+
+    <code-example title="Basic Example" :code="basicExample">
+      <template v-slot:example>
+        <Table
+          :items="items"
+          :headers="headers"
+        />
+      </template>
+    </code-example>
+
+    <br/>
+    <br/>
+
+    <usage :props="props" :slots="slots"/>
+
+  </div>
+</template>
+
+<script>
+// eslint-disable-next-line no-useless-escape
+const basicExample = '<template>\n  <Table\n    :items=\"items\"\n    :headers=\"headers\"\n  \/>\n<\/template>\n\n<script>\nexport default {\n  name: \'TableExample\',\n  data: () => ({\n    headers: [\n      {\n        label: \'Label1\',\n        valueKey: \'Value1\',\n        rightAlign: false,\n      },\n      {\n        label: \'Label2\',\n        valueKey: \'Value2\',\n        rightAlign: false,\n      },\n      {\n        label: \'Label3\',\n        valueKey: \'Value3\',\n        rightAlign: false,\n      },\n      {\n        label: \'Label4\',\n        valueKey: \'Value4\',\n        rightAlign: false,\n      },\n    ],\n    items: [\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n    ],\n  }),\n};\n<\/script>';
+
+export default {
+  name: 'TableDocs',
+  data: () => ({
+    headers: [
+      {
+        label: 'Label1',
+        valueKey: 'Value1',
+        rightAlign: true,
+      },
+      {
+        label: 'Label2',
+        valueKey: 'Value2',
+        rightAlign: false,
+      },
+      {
+        label: 'Label3',
+        valueKey: 'Value3',
+        rightAlign: false,
+      },
+      {
+        label: 'Label4',
+        valueKey: 'Value4',
+        rightAlign: false,
+      },
+    ],
+    items: [
+      {
+        Value1: 'Value1',
+        Value2: 'Value2',
+        Value3: 'Value3',
+        Value4: 'Value4',
+      },
+      {
+        Value1: 'Value1',
+        Value2: 'Value2',
+        Value3: 'Value3',
+        Value4: 'Value4',
+      },
+      {
+        Value1: 'Value1',
+        Value2: 'Value2',
+        Value3: 'Value3',
+        Value4: 'Value4',
+      },
+      {
+        Value1: 'Value1',
+        Value2: 'Value2',
+        Value3: 'Value3',
+        Value4: 'Value4',
+      },
+    ],
+    props: [
+      {
+        name: 'Headers',
+        type: 'Array',
+        description: 'Array of header objects {label: x, valueKey: x, rightAlign: x}',
+      },
+      {
+        name: 'Items',
+        type: 'Array',
+        description: 'Array of item objects',
+      },
+    ],
+    slots: [],
+    basicExample,
+  }),
+};
+</script>
+
+<style scoped>
+.divider {
+  margin: 32px 0px;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import Router from 'vue-router';
 import LandingPage from '../docs/LandingPage.vue';
 import ImageContainerDocs from '../docs/ImageContainerDocs.vue';
 import CardDocs from '../docs/CardDocs.vue';
+import TableDocs from '../docs/TableDocs.vue';
 
 Vue.use(Router);
 
@@ -27,6 +28,11 @@ export default new Router({
       path: '/Card',
       name: 'Card',
       component: CardDocs,
+    },
+    {
+      path: '/Table',
+      name: 'Table',
+      component: TableDocs,
     },
   ],
 });


### PR DESCRIPTION
## Feature
![image](https://user-images.githubusercontent.com/11461961/95122018-30a79800-0750-11eb-8ec2-cdc239106a33.png)

In issue #16, you want a table component. I created it as I understood you in the description.

## PR caveat
The border below the header is a pain in the ass to get _right_;
![image](https://user-images.githubusercontent.com/11461961/95123588-7cf3d780-0752-11eb-8090-850f34230564.png)

I ended up with just doing basic `th: {border-bottom: 2px dashed}`. The problem with this approach is that the dashed lines will not have equal white-space (because it is on each th-element). I tried a lot of different solutions to fix this, went up and down StackOverflow for hacks. I almost landed on creating the border with CSS gradients [as specified in this SO post](https://stackoverflow.com/a/31315911/6178832) but translating this to table was no success.

Of course, just adding a `thead:after` with a dashed border on it **solves this whole problem** with ease! The downside with this approach is that we are breaking the end user's ability to use `position: absolute` inside the table to go "outside the table". If this is not something you have a concern about, this will work 100%. If not, I believe it will be hard to achieve the result you want. I would LOVE to see if someone is able to fix this, please @ me in that case with the solution.

## Feedback
I believe the API could be improved a bit in order to make the component props more customizable. By adding a reduce prop, the user could choose what function should be run to display the items for example instead of forcing the user to use the pattern `'label', 'valueKey', 'rightAlign'` on the headers
