### PR TITLE
Rename valueKey & rightAlign, change rightAlign api

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -6,7 +6,7 @@
           <th
             v-for="(header, index) in headers"
             :key="index"
-            :style="{ textAlign: header.rightAlign ? 'right' : 'initial'  }"
+            :style="{ textAlign: header.align ? header.align : 'left'  }"
           >
             {{ header.label }}
           </th>
@@ -17,9 +17,9 @@
           <td
             v-for="(col, colIndex) in Object.keys(row).length"
             :key="'col' + colIndex"
-            :style="{ textAlign: headers[colIndex].rightAlign ? 'right' : 'initial'  }"
+            :style="{ textAlign: headers[colIndex].align ? headers[colIndex].align : 'left'  }"
           >
-            {{ row[headers[colIndex].valueKey] }}
+            {{ row[headers[colIndex].value] }}
           </td>
         </tr>
       </tbody>
@@ -43,7 +43,7 @@ export default {
       required: true,
       default: () => [],
       validator: (headers) => {
-        const requiredKeys = ['label', 'valueKey', 'rightAlign'];
+        const requiredKeys = ['label', 'valueKey'];
         return headers.every(
           (header) => requiredKeys.every(
             (key) => Object.prototype.hasOwnProperty.call(header, key),

--- a/src/docs/TableDocs.vue
+++ b/src/docs/TableDocs.vue
@@ -30,7 +30,7 @@
 
 <script>
 // eslint-disable-next-line no-useless-escape
-const basicExample = '<template>\n  <Table\n    :items=\"items\"\n    :headers=\"headers\"\n  \/>\n<\/template>\n\n<script>\nexport default {\n  name: \'TableExample\',\n  data: () => ({\n    headers: [\n      {\n        label: \'Label1\',\n        valueKey: \'Value1\',\n        rightAlign: false,\n      },\n      {\n        label: \'Label2\',\n        valueKey: \'Value2\',\n        rightAlign: false,\n      },\n      {\n        label: \'Label3\',\n        valueKey: \'Value3\',\n        rightAlign: false,\n      },\n      {\n        label: \'Label4\',\n        valueKey: \'Value4\',\n        rightAlign: false,\n      },\n    ],\n    items: [\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n    ],\n  }),\n};\n<\/script>';
+const basicExample = '<template>\n  <Table\n    :items=\"items\"\n    :headers=\"headers\"\n  \/>\n<\/template>\n\n<script>\nexport default {\n  name: \'TableExample\',\n  data: () => ({\n    headers: [\n      {\n        label: \'Label1\',\n        value: \'Value1\',\n        },\n      {\n        label: \'Label2\',\n        value: \'Value2\',\n        },\n      {\n        label: \'Label3\',\n        value: \'Value3\',\n        },\n      {\n        label: \'Label4\',\n        value: \'Value4\',\n        align: \'right\',\n      },\n    ],\n    items: [\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n      {\n        Value1: \'Value1\',\n        Value2: \'Value2\',\n        Value3: \'Value3\',\n        Value4: \'Value4\',\n      },\n    ],\n  }),\n};\n<\/script>';
 
 export default {
   name: 'TableDocs',
@@ -38,23 +38,20 @@ export default {
     headers: [
       {
         label: 'Label1',
-        valueKey: 'Value1',
-        rightAlign: true,
+        value: 'Value1',
       },
       {
         label: 'Label2',
-        valueKey: 'Value2',
-        rightAlign: false,
+        value: 'Value2',
       },
       {
         label: 'Label3',
-        valueKey: 'Value3',
-        rightAlign: false,
+        value: 'Value3',
       },
       {
         label: 'Label4',
-        valueKey: 'Value4',
-        rightAlign: false,
+        value: 'Value4',
+        align: 'right',
       },
     ],
     items: [
@@ -87,7 +84,7 @@ export default {
       {
         name: 'Headers',
         type: 'Array',
-        description: 'Array of header objects {label: x, valueKey: x, rightAlign: x}',
+        description: 'Array of header objects {label: x, value: x, align: x}',
       },
       {
         name: 'Items',


### PR DESCRIPTION
As commented in #25 

## Breaking changes
#### Headers prop
* `valueKey` renamed to `value`
* `rightAlign` renamed to `align`
    * Supported type changed from `Boolean` to `String`

    | Key        | Type    | Values                  |
    |------------|---------|-------------------------|
    | ~~rightAlign~~ | ~~Boolean~~ | ~~true \| false~~           |
    | align      | String  | left \| center \| right |