### PR TITLE
Table full width - Fixes #24

### DIFF
--- a/src/components/FgTable.vue
+++ b/src/components/FgTable.vue
@@ -56,6 +56,10 @@ export default {
 </script>
 
 <style scoped>
+.table-container table {
+  table-layout: fixed;
+  width: 100%;
+}
 .table-container th {
   font-weight: normal;
   border-bottom: 2px dashed;


### PR DESCRIPTION
Issue #24 - have table be full-width of its parent. I have added the CSS property of table-layout to fixed. Here is the CSS property description from MDN documentation:

> Table and column widths are set by the widths of table and col elements or by the width of the first row of cells. Cells in subsequent rows do not affect column widths.
Under the "fixed" layout method, the entire table can be rendered once the first table row has been downloaded and analyzed. This can speed up rendering time over the "automatic" layout method, but subsequent cell content might not fit in the column widths provided. Cells use the overflow property to determine whether to clip any overflowing content, but only if the table has a known width; otherwise, they won't overflow the cells.

[MDN table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout)